### PR TITLE
Update cursor text for mute/unmute status and adjust cursor text size for better responsiveness

### DIFF
--- a/src/components/CustomCursorGSAP.astro
+++ b/src/components/CustomCursorGSAP.astro
@@ -44,7 +44,7 @@
     transition: opacity 0.3s ease;
   }
   .cursor-text {
-    font-size: 1rem;
+    font-size: calc(0.675rem * 1.5vw);
   }
 </style>
 
@@ -135,7 +135,7 @@
     video?.addEventListener("mousemove", () => {
       gsap.to(cursor, {
         scale: 3.5,
-        autoAlpha: 0.9,
+        autoAlpha: 1,
         backgroundColor: "transparent",
         duration: 0.1,
       });

--- a/src/components/CustomVideoPlayer.astro
+++ b/src/components/CustomVideoPlayer.astro
@@ -100,7 +100,7 @@ const {
     // Update de cursor-tekst (Mute / Unmute) gebaseerd op de status van de video
     function updateCursorText(video) {
       if (!cursorText) return;
-      cursorText.textContent = video.muted ? "ummute" : "mute";
+      cursorText.textContent = video.muted ? "unmute" : "mute";
     }
 
     // Voeg click-event toe aan elke video


### PR DESCRIPTION
## Summary by Sourcery

Improve the responsiveness and visibility of the custom cursor by adjusting the text size based on viewport width and increasing the cursor's visibility during video interaction. Fix a typo in the cursor text for mute/unmute status.

Bug Fixes:
- Correct the cursor text from 'ummute' to 'unmute' for video mute status.

Enhancements:
- Adjust the cursor text size to be responsive using a calculation based on viewport width.
- Increase the cursor's autoAlpha property to 1 for better visibility during mouse movement over video.